### PR TITLE
Improve site style

### DIFF
--- a/static/css/estilo.css
+++ b/static/css/estilo.css
@@ -1,0 +1,117 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+  margin: 0;
+  padding: 0;
+  color: #333;
+}
+
+.navbar {
+  background-color: #333;
+  color: #fff;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.navbar a {
+  color: #fff;
+  margin-left: 15px;
+  text-decoration: none;
+}
+.navbar .logo {
+  font-weight: bold;
+  font-size: 1.2em;
+}
+
+.container {
+  padding: 20px;
+  max-width: 1000px;
+  margin: auto;
+}
+
+.produtos {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 20px;
+}
+.produto {
+  background: #fff;
+  padding: 15px;
+  border-radius: 5px;
+  text-align: center;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+.produto img {
+  max-width: 100%;
+  height: auto;
+}
+.produto h3 {
+  margin: 10px 0 5px;
+}
+.produto .preco {
+  color: #0a7;
+  font-weight: bold;
+}
+
+form.form {
+  max-width: 400px;
+  margin: auto;
+}
+form.form input[type="text"],
+form.form input[type="email"],
+form.form input[type="password"] {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}
+
+button, .botao-comprar {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  padding: 10px 15px;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+button:hover, .botao-comprar:hover {
+  background-color: #0056b3;
+}
+
+.carrinho-lista ul {
+  list-style: none;
+  padding: 0;
+}
+.carrinho-lista li {
+  background: #fff;
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+}
+
+.pedido {
+  background: #fff;
+  border: 1px solid #ddd;
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+}
+
+.flashes {
+  margin-bottom: 20px;
+}
+.flash-message {
+  padding: 10px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+}
+.flash-message.success { background: #d4edda; color: #155724; }
+.flash-message.info { background: #cce5ff; color: #004085; }
+.flash-message.warning { background: #fff3cd; color: #856404; }
+.flash-message.danger { background: #f8d7da; color: #721c24; }
+

--- a/static/js/loja.js
+++ b/static/js/loja.js
@@ -1,1 +1,8 @@
-// This file is intentionally left blank.
+document.addEventListener('DOMContentLoaded', function () {
+  const flashes = document.querySelectorAll('.flash-message');
+  if (flashes.length) {
+    setTimeout(() => {
+      flashes.forEach(el => el.style.display = 'none');
+    }, 3000);
+  }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -6,33 +6,34 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/estilo.css') }}">
 </head>
 <body>
-  <nav>
-    {% if current_user.is_authenticated %}
-      <p>Usuário: {{ current_user.nome }} {% if current_user.admin %}(Admin){% endif %}</p>
-      <a href="{{ url_for('auth.logout') }}">Logout</a>
-      <ul>
-        <li><a href="{{ url_for('loja.meus_pedidos') }}">Meus Pedidos</a></li>
-      </ul>
-      {% if current_user.admin %}
-        <ul>
-          <li><a href="{{ url_for('loja.pedidos_admin') }}">Painel Admin</a></li>
-        </ul>
+  <nav class="navbar">
+    <a href="{{ url_for('loja.index') }}" class="logo">Imperium Tech</a>
+    <div class="nav-links">
+      <a href="{{ url_for('carrinho.ver_carrinho') }}">Carrinho</a>
+      {% if current_user.is_authenticated %}
+        <span class="user">Olá, {{ current_user.nome }}{% if current_user.admin %} (Admin){% endif %}</span>
+        <a href="{{ url_for('loja.meus_pedidos') }}">Meus Pedidos</a>
+        {% if current_user.admin %}
+          <a href="{{ url_for('loja.pedidos_admin') }}">Painel Admin</a>
+        {% endif %}
+        <a href="{{ url_for('auth.logout') }}">Logout</a>
+      {% else %}
+        <a href="{{ url_for('auth.login') }}">Login</a>
       {% endif %}
-    {% else %}
-      <a href="{{ url_for('auth.login') }}">Login</a>
-    {% endif %}
+    </div>
   </nav>
-  <main>
-    {% with messages = get_flashed_messages() %}
+  <main class="container">
+    {% with messages = get_flashed_messages(with_categories=True) %}
       {% if messages %}
-        <ul>
-        {% for msg in messages %}
-          <li>{{ msg }}</li>
-        {% endfor %}
-        </ul>
+        <div class="flashes">
+          {% for category, msg in messages %}
+            <div class="flash-message {{ category }}">{{ msg }}</div>
+          {% endfor %}
+        </div>
       {% endif %}
     {% endwith %}
     {% block content %}{% endblock %}
   </main>
+  <script src="{{ url_for('static', filename='js/loja.js') }}"></script>
 </body>
 </html>

--- a/templates/cadastro.html
+++ b/templates/cadastro.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Cadastro</h2>
-<form method="POST">
+<form method="POST" class="form">
   <input type="text" name="nome" placeholder="Nome" required><br>
   <input type="email" name="email" placeholder="E-mail" required><br>
   <input type="password" name="senha" placeholder="Senha" required><br>

--- a/templates/carrinho.html
+++ b/templates/carrinho.html
@@ -1,31 +1,25 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Carrinho de Compras</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/estilo.css') }}">
-</head>
-<body>
-    <h1>Seu Carrinho</h1>
-    {% if produtos %}
-        <ul>
-            {% for item in produtos %}
-                <li>
-                    {{ item.produto.nome }} ({{ item.quantidade }}) - R$ {{ "%.2f"|format(item.subtotal) }}
-                    <form action="{{ url_for('carrinho.remover_do_carrinho') }}" method="post" style="display:inline;">
-                        <input type="hidden" name="produto_id" value="{{ item.produto.id }}">
-                        <button type="submit" class="btn btn-danger btn-sm">Remover</button>
-                    </form>
-                </li>
-            {% endfor %}
-        </ul>
-        <p><strong>Total:</strong> R$ {{ "%.2f"|format(total) }}</p>
-        <form action="{{ url_for('carrinho.finalizar_compra') }}" method="post">
-            <button type="submit" class="btn btn-success">Finalizar Compra</button>
-        </form>
-
-    {% else %}
-        <p>Seu carrinho está vazio.</p>
-    {% endif %}
-</body>
-</html>
+{% extends 'base.html' %}
+{% block content %}
+<h1>Seu Carrinho</h1>
+<div class="carrinho-lista">
+  {% if produtos %}
+    <ul>
+      {% for item in produtos %}
+        <li>
+          {{ item.produto.nome }} ({{ item.quantidade }}) - R$ {{ "%.2f"|format(item.subtotal) }}
+          <form action="{{ url_for('carrinho.remover_do_carrinho') }}" method="post" style="display:inline;">
+            <input type="hidden" name="produto_id" value="{{ item.produto.id }}">
+            <button type="submit">Remover</button>
+          </form>
+        </li>
+      {% endfor %}
+    </ul>
+    <p><strong>Total:</strong> R$ {{ "%.2f"|format(total) }}</p>
+    <form action="{{ url_for('carrinho.finalizar_compra') }}" method="post">
+      <button type="submit" class="botao-comprar">Finalizar Compra</button>
+    </form>
+  {% else %}
+    <p>Seu carrinho está vazio.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,23 +1,15 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>Loja de Informática</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <a href="{{ url_for('auth.login') }}" class="btn-login">Login</a>
-    <a href="{{ url_for('carrinho.ver_carrinho') }}" class="btn-carrinho">🛒 Carrinho</a>
-    <h1>Produtos disponíveis</h1>
-    <div class="produtos">
-        {% for produto in produtos %}
-            <div class="produto">
-                <a href="{{ url_for('loja.produto_detalhe', id=produto.id) }}">
-                    <img src="{{ produto.imagem }}" width="200"><br>
-                    {{ produto.nome }} - R$ {{ "%.2f"|format(produto.preco) }}
-                </a>
-            </div>
-        {% endfor %}
+{% extends 'base.html' %}
+{% block content %}
+<h1>Produtos disponíveis</h1>
+<div class="produtos">
+  {% for produto in produtos %}
+    <div class="produto">
+      <a href="{{ url_for('loja.produto_detalhe', id=produto.id) }}">
+        <img src="{{ produto.imagem }}" alt="Imagem de {{ produto.nome }}">
+        <h3>{{ produto.nome }}</h3>
+        <p class="preco">R$ {{ "%.2f"|format(produto.preco) }}</p>
+      </a>
     </div>
-</body>
-</html>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,11 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Login</h2>
-<form method="POST">
+<form method="POST" class="form">
   <input type="email" name="email" placeholder="E-mail" required><br>
   <input type="password" name="senha" placeholder="Senha" required><br>
   <button type="submit">Entrar</button>
 </form>
 <a href="{{ url_for('auth.cadastro') }}">Não tem conta? Cadastre-se</a>
 {% endblock %}
-    

--- a/templates/produto_detalhe.html
+++ b/templates/produto_detalhe.html
@@ -1,19 +1,12 @@
-<!DOCTYPE html>
-<html lang="pt-br">
-<head>
-    <meta charset="UTF-8">
-    <title>{{ produto.nome }}</title>
-</head>
-<body>
-    <h1>{{ produto.nome }}</h1>
-    <img src="{{ produto.imagem }}" width="300" alt="Imagem de {{ produto.nome }}">
-    <p><strong>Marca:</strong> {{ produto.marca }}</p>
-    <p><strong>Preço:</strong> R$ {{ produto.preco }}</p>
-    <p><strong>Descrição:</strong> {{ produto.descricao }}</p>
-    <p><strong>Estoque disponível:</strong> {{ produto.estoque }}</p>
-
-    <a href="{{ url_for('carrinho.adicionar_ao_carrinho', id=produto.id) }}" class="botao-comprar">Adicionar ao Carrinho</a>
-    <br>
-    <a href="/">Voltar à loja</a>
-</body> 
-</html>
+{% extends 'base.html' %}
+{% block content %}
+<h1>{{ produto.nome }}</h1>
+<img src="{{ produto.imagem }}" width="300" alt="Imagem de {{ produto.nome }}">
+<p><strong>Marca:</strong> {{ produto.marca }}</p>
+<p><strong>Preço:</strong> R$ {{ produto.preco }}</p>
+<p><strong>Descrição:</strong> {{ produto.descricao }}</p>
+<p><strong>Estoque disponível:</strong> {{ produto.estoque }}</p>
+<a href="{{ url_for('carrinho.adicionar_ao_carrinho', id=produto.id) }}" class="botao-comprar">Adicionar ao Carrinho</a>
+<br>
+<a href="{{ url_for('loja.index') }}">Voltar à loja</a>
+{% endblock %}


### PR DESCRIPTION
## Summary
- style navigation and layout via `estilo.css`
- add fade out for flash messages
- redesign `base.html` and extend it across pages
- update product, cart, login and signup views

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404f58d8448328bb0802e7c2ef7c95