### PR TITLE
Implement admin panel

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from flask_mail import Mail
 from models import db  # use o db do models
 from models.usuario import Usuario
 from routes import loja_routes, auth_routes, api_routes
+from routes.admin_routes import admin_bp
 from routes.loja_routes import loja
 from routes.carrinho_routes import carrinho_bp
 from routes.usuario_routes import usuario_bp
@@ -39,6 +40,7 @@ app.register_blueprint(api_routes.bp)
 app.register_blueprint(loja)
 app.register_blueprint(carrinho_bp, url_prefix='/carrinho')
 app.register_blueprint(usuario_bp)
+app.register_blueprint(admin_bp)
 
 mail = Mail(app)
 serializer = URLSafeTimedSerializer(app.secret_key)

--- a/forms.py
+++ b/forms.py
@@ -1,0 +1,21 @@
+from flask_wtf import FlaskForm
+from wtforms import StringField, FloatField, IntegerField, TextAreaField, SubmitField, SelectField, PasswordField
+from wtforms.validators import DataRequired
+
+class ProductForm(FlaskForm):
+    nome = StringField('Nome', validators=[DataRequired()])
+    marca = StringField('Marca', validators=[DataRequired()])
+    descricao = TextAreaField('Descrição', validators=[DataRequired()])
+    preco = FloatField('Preço', validators=[DataRequired()])
+    estoque = IntegerField('Estoque', validators=[DataRequired()])
+    imagem = StringField('Imagem')
+    submit = SubmitField('Salvar')
+
+class OrderFilterForm(FlaskForm):
+    status = SelectField('Status', choices=[('todos','Todos'), ('pendente','Pendente'), ('entregue','Entregue'), ('cancelado','Cancelado')])
+    submit = SubmitField('Filtrar')
+
+class AdminLoginForm(FlaskForm):
+    email = StringField('E-mail', validators=[DataRequired()])
+    senha = PasswordField('Senha', validators=[DataRequired()])
+    submit = SubmitField('Entrar')

--- a/models/admin_log.py
+++ b/models/admin_log.py
@@ -1,0 +1,10 @@
+from datetime import datetime
+from models import db
+
+class AdminLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
+    acao = db.Column(db.String(255), nullable=False)
+    data = db.Column(db.DateTime, default=datetime.utcnow)
+
+    usuario = db.relationship('Usuario')

--- a/models/pedido.py
+++ b/models/pedido.py
@@ -6,5 +6,6 @@ class Pedido(db.Model):
     usuario_id = db.Column(db.Integer, db.ForeignKey('usuario.id'), nullable=False)
     data = db.Column(db.DateTime, default=datetime.utcnow)
     total = db.Column(db.Float, nullable=False)
+    status = db.Column(db.String(20), default='pendente')
 
     usuario = db.relationship('Usuario', backref=db.backref('pedidos', lazy=True))

--- a/models/usuario.py
+++ b/models/usuario.py
@@ -8,6 +8,7 @@ class Usuario(db.Model, UserMixin):
     senha = db.Column(db.String(200), nullable=False)
     admin = db.Column(db.Boolean, default=False)  # NOVO CAMPO
     verificado = db.Column(db.Boolean, default=False)
+    ativo = db.Column(db.Boolean, default=True)
 
     @classmethod
     def get(cls, user_id):

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -3,3 +3,4 @@
 from .auth_routes import *
 from .loja_routes import *
 from .api_routes import *
+from .admin_routes import *

--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -1,0 +1,177 @@
+from flask import Blueprint, render_template, redirect, url_for, request, flash
+from flask_login import login_user, logout_user, login_required, current_user
+from werkzeug.security import check_password_hash
+
+from models import db
+from models.produto import Produto
+from models.pedido import Pedido
+from models.usuario import Usuario
+from models.admin_log import AdminLog
+from forms import ProductForm, OrderFilterForm, AdminLoginForm
+
+admin_bp = Blueprint('admin', __name__, url_prefix='/admin')
+
+
+def log_action(acao):
+    if current_user.is_authenticated and current_user.admin:
+        log = AdminLog(usuario_id=current_user.id, acao=acao)
+        db.session.add(log)
+        db.session.commit()
+
+
+@admin_bp.route('/login', methods=['GET', 'POST'])
+def login():
+    form = AdminLoginForm()
+    if form.validate_on_submit():
+        user = Usuario.query.filter_by(email=form.email.data, admin=True).first()
+        if user and check_password_hash(user.senha, form.senha.data):
+            login_user(user)
+            flash('Login de administrador realizado com sucesso!', 'success')
+            return redirect(url_for('admin.dashboard'))
+        flash('Credenciais inválidas ou usuário não é administrador.', 'danger')
+    return render_template('admin/login.html', form=form)
+
+
+@admin_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    flash('Logout realizado.', 'info')
+    return redirect(url_for('admin.login'))
+
+
+@admin_bp.route('/dashboard')
+@login_required
+def dashboard():
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    total_produtos = Produto.query.count()
+    total_usuarios = Usuario.query.count()
+    total_pedidos = Pedido.query.count()
+    return render_template('admin/dashboard.html',
+                           total_produtos=total_produtos,
+                           total_usuarios=total_usuarios,
+                           total_pedidos=total_pedidos)
+
+
+@admin_bp.route('/produtos')
+@login_required
+def produtos():
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    produtos = Produto.query.all()
+    return render_template('admin/produtos/lista.html', produtos=produtos)
+
+
+@admin_bp.route('/produtos/novo', methods=['GET', 'POST'])
+@login_required
+def produto_novo():
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    form = ProductForm()
+    if form.validate_on_submit():
+        produto = Produto(nome=form.nome.data,
+                          marca=form.marca.data,
+                          descricao=form.descricao.data,
+                          preco=form.preco.data,
+                          estoque=form.estoque.data,
+                          imagem=form.imagem.data)
+        db.session.add(produto)
+        db.session.commit()
+        log_action(f'Adicionou produto {produto.nome}')
+        flash('Produto adicionado com sucesso.', 'success')
+        return redirect(url_for('admin.produtos'))
+    return render_template('admin/produtos/form.html', form=form)
+
+
+@admin_bp.route('/produtos/<int:produto_id>/editar', methods=['GET', 'POST'])
+@login_required
+def produto_editar(produto_id):
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    produto = Produto.query.get_or_404(produto_id)
+    form = ProductForm(obj=produto)
+    if form.validate_on_submit():
+        form.populate_obj(produto)
+        db.session.commit()
+        log_action(f'Editou produto {produto.nome}')
+        flash('Produto atualizado.', 'success')
+        return redirect(url_for('admin.produtos'))
+    return render_template('admin/produtos/form.html', form=form, produto=produto)
+
+
+@admin_bp.route('/produtos/<int:produto_id>/excluir', methods=['POST'])
+@login_required
+def produto_excluir(produto_id):
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    produto = Produto.query.get_or_404(produto_id)
+    db.session.delete(produto)
+    db.session.commit()
+    log_action(f'Excluiu produto {produto.nome}')
+    flash('Produto excluído.', 'info')
+    return redirect(url_for('admin.produtos'))
+
+
+@admin_bp.route('/pedidos', methods=['GET', 'POST'])
+@login_required
+def pedidos():
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    form = OrderFilterForm()
+    query = Pedido.query
+    if form.validate_on_submit() and form.status.data != 'todos':
+        query = query.filter_by(status=form.status.data)
+    pedidos = query.order_by(Pedido.data.desc()).all()
+    return render_template('admin/pedidos/lista.html', pedidos=pedidos, form=form)
+
+
+@admin_bp.route('/pedidos/<int:pedido_id>')
+@login_required
+def pedido_detalhe(pedido_id):
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    pedido = Pedido.query.get_or_404(pedido_id)
+    return render_template('admin/pedidos/detalhe.html', pedido=pedido)
+
+
+@admin_bp.route('/usuarios')
+@login_required
+def usuarios():
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    usuarios = Usuario.query.all()
+    return render_template('admin/usuarios/lista.html', usuarios=usuarios)
+
+
+@admin_bp.route('/usuarios/<int:usuario_id>/promover', methods=['POST'])
+@login_required
+def usuario_promover(usuario_id):
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    usuario = Usuario.query.get_or_404(usuario_id)
+    usuario.admin = not usuario.admin
+    db.session.commit()
+    log_action(f'Alterou privilégio de {usuario.nome}')
+    return redirect(url_for('admin.usuarios'))
+
+
+@admin_bp.route('/usuarios/<int:usuario_id>/desativar', methods=['POST'])
+@login_required
+def usuario_desativar(usuario_id):
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    usuario = Usuario.query.get_or_404(usuario_id)
+    usuario.ativo = not usuario.ativo
+    db.session.commit()
+    log_action(f'Alterou status de {usuario.nome}')
+    return redirect(url_for('admin.usuarios'))
+
+
+@admin_bp.route('/logs')
+@login_required
+def logs():
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+    logs = AdminLog.query.order_by(AdminLog.data.desc()).all()
+    return render_template('admin/logs.html', logs=logs)

--- a/templates/admin/base.html
+++ b/templates/admin/base.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <title>Painel Admin - Imperium</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark navbar-expand-lg">
+    <div class="container-fluid">
+        <a class="navbar-brand" href="{{ url_for('admin.dashboard') }}">Admin Imperium</a>
+        <div class="collapse navbar-collapse">
+            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.produtos') }}">Produtos</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.pedidos') }}">Pedidos</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.usuarios') }}">Usuários</a></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.logs') }}">Logs</a></li>
+            </ul>
+            <ul class="navbar-nav">
+                {% if current_user.is_authenticated %}
+                <li class="nav-item"><span class="navbar-text me-2">{{ current_user.nome }}</span></li>
+                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.logout') }}">Sair</a></li>
+                {% endif %}
+            </ul>
+        </div>
+    </div>
+</nav>
+<div class="container mt-4">
+    {% with messages = get_flashed_messages(with_categories=True) %}
+    {% if messages %}
+    {% for cat, msg in messages %}
+    <div class="alert alert-{{ cat }}">{{ msg }}</div>
+    {% endfor %}
+    {% endif %}
+    {% endwith %}
+    {% block content %}{% endblock %}
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,30 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h1>Dashboard</h1>
+<div class="row">
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Produtos</h5>
+                <p class="card-text display-6">{{ total_produtos }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Usuários</h5>
+                <p class="card-text display-6">{{ total_usuarios }}</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+        <div class="card text-center">
+            <div class="card-body">
+                <h5 class="card-title">Pedidos</h5>
+                <p class="card-text display-6">{{ total_pedidos }}</p>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/login.html
+++ b/templates/admin/login.html
@@ -1,0 +1,16 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>Login Administrador</h2>
+<form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+        {{ form.email.label(class="form-label") }}
+        {{ form.email(class="form-control") }}
+    </div>
+    <div class="mb-3">
+        {{ form.senha.label(class="form-label") }}
+        {{ form.senha(class="form-control") }}
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/templates/admin/logs.html
+++ b/templates/admin/logs.html
@@ -1,0 +1,22 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>Logs Administrativos</h2>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>Data</th>
+            <th>Admin</th>
+            <th>Ação</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for log in logs %}
+        <tr>
+            <td>{{ log.data.strftime('%d/%m/%Y %H:%M') }}</td>
+            <td>{{ log.usuario.nome }}</td>
+            <td>{{ log.acao }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/admin/pedidos/detalhe.html
+++ b/templates/admin/pedidos/detalhe.html
@@ -1,0 +1,14 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>Pedido #{{ pedido.id }}</h2>
+<p><strong>Usuário:</strong> {{ pedido.usuario.nome }} ({{ pedido.usuario.email }})</p>
+<p><strong>Data:</strong> {{ pedido.data.strftime('%d/%m/%Y %H:%M') }}</p>
+<p><strong>Status:</strong> {{ pedido.status }}</p>
+<p><strong>Total:</strong> R$ {{ '%.2f'|format(pedido.total) }}</p>
+<ul class="list-group mb-3">
+{% for item in pedido.itens %}
+  <li class="list-group-item">{{ item.produto.nome }} - {{ item.quantidade }}x</li>
+{% endfor %}
+</ul>
+<a href="{{ url_for('admin.pedidos') }}" class="btn btn-secondary">Voltar</a>
+{% endblock %}

--- a/templates/admin/pedidos/lista.html
+++ b/templates/admin/pedidos/lista.html
@@ -1,0 +1,37 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>Pedidos</h2>
+<form method="POST" class="row g-3 mb-3">
+    {{ form.hidden_tag() }}
+    <div class="col-auto">
+        {{ form.status(class="form-select") }}
+    </div>
+    <div class="col-auto">
+        {{ form.submit(class="btn btn-primary") }}
+    </div>
+</form>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Usuário</th>
+            <th>Data</th>
+            <th>Total</th>
+            <th>Status</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for p in pedidos %}
+        <tr>
+            <td>{{ p.id }}</td>
+            <td>{{ p.usuario.nome }}</td>
+            <td>{{ p.data.strftime('%d/%m/%Y %H:%M') }}</td>
+            <td>R$ {{ '%.2f'|format(p.total) }}</td>
+            <td>{{ p.status }}</td>
+            <td><a href="{{ url_for('admin.pedido_detalhe', pedido_id=p.id) }}" class="btn btn-sm btn-secondary">Ver</a></td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/admin/produtos/form.html
+++ b/templates/admin/produtos/form.html
@@ -1,0 +1,34 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>{% if produto %}Editar{% else %}Novo{% endif %} Produto</h2>
+<form method="POST">
+    {{ form.hidden_tag() }}
+    <div class="mb-3">
+        {{ form.nome.label(class="form-label") }}
+        {{ form.nome(class="form-control") }}
+    </div>
+    <div class="mb-3">
+        {{ form.marca.label(class="form-label") }}
+        {{ form.marca(class="form-control") }}
+    </div>
+    <div class="mb-3">
+        {{ form.descricao.label(class="form-label") }}
+        {{ form.descricao(class="form-control", rows=3) }}
+    </div>
+    <div class="row">
+        <div class="col-md-4 mb-3">
+            {{ form.preco.label(class="form-label") }}
+            {{ form.preco(class="form-control") }}
+        </div>
+        <div class="col-md-4 mb-3">
+            {{ form.estoque.label(class="form-label") }}
+            {{ form.estoque(class="form-control") }}
+        </div>
+        <div class="col-md-4 mb-3">
+            {{ form.imagem.label(class="form-label") }}
+            {{ form.imagem(class="form-control") }}
+        </div>
+    </div>
+    {{ form.submit(class="btn btn-primary") }}
+</form>
+{% endblock %}

--- a/templates/admin/produtos/lista.html
+++ b/templates/admin/produtos/lista.html
@@ -1,0 +1,32 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>Produtos</h2>
+<a href="{{ url_for('admin.produto_novo') }}" class="btn btn-success mb-3">Novo Produto</a>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nome</th>
+            <th>Preço</th>
+            <th>Estoque</th>
+            <th>Ações</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for p in produtos %}
+        <tr>
+            <td>{{ p.id }}</td>
+            <td>{{ p.nome }}</td>
+            <td>R$ {{ '%.2f'|format(p.preco) }}</td>
+            <td>{{ p.estoque }}</td>
+            <td>
+                <a href="{{ url_for('admin.produto_editar', produto_id=p.id) }}" class="btn btn-sm btn-primary">Editar</a>
+                <form method="POST" action="{{ url_for('admin.produto_excluir', produto_id=p.id) }}" style="display:inline-block;">
+                    <button class="btn btn-sm btn-danger" onclick="return confirm('Excluir produto?')">Excluir</button>
+                </form>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/admin/usuarios/lista.html
+++ b/templates/admin/usuarios/lista.html
@@ -1,0 +1,35 @@
+{% extends 'admin/base.html' %}
+{% block content %}
+<h2>Usuários</h2>
+<table class="table table-striped">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nome</th>
+            <th>Email</th>
+            <th>Admin</th>
+            <th>Ativo</th>
+            <th>Ações</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for u in usuarios %}
+        <tr>
+            <td>{{ u.id }}</td>
+            <td>{{ u.nome }}</td>
+            <td>{{ u.email }}</td>
+            <td>{{ 'Sim' if u.admin else 'Não' }}</td>
+            <td>{{ 'Sim' if u.ativo else 'Não' }}</td>
+            <td>
+                <form method="POST" action="{{ url_for('admin.usuario_promover', usuario_id=u.id) }}" style="display:inline">
+                    <button class="btn btn-sm btn-warning">{% if u.admin %}Revogar{% else %}Promover{% endif %}</button>
+                </form>
+                <form method="POST" action="{{ url_for('admin.usuario_desativar', usuario_id=u.id) }}" style="display:inline">
+                    <button class="btn btn-sm btn-secondary">{% if u.ativo %}Desativar{% else %}Ativar{% endif %}</button>
+                </form>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin blueprint with CRUD routes
- add Flask-WTF forms for admin panel
- add models for order status and admin logs
- add templates for admin dashboard, login, product management, orders, users, and logs
- register admin blueprint in app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407cebfafc83289ca3efa557159db2