### PR TITLE
Implement password policy and email password reset flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import os
+
+from dotenv import load_dotenv
 from flask import Flask
 from flask_login import LoginManager
 from flask_mail import Mail
@@ -14,17 +17,23 @@ from flask import flash, redirect, request, render_template, url_for
 from werkzeug.security import generate_password_hash
 from utils.email_utils import enviar_email
     
+load_dotenv()
+
 app = Flask(__name__)
 app.config.from_object('config.Config')
 app.secret_key = 'sua-chave-secreta'  # Adicionando a chave secreta
 
-# Looking to send emails in production? Check out our Email API/SMTP product!
-app.config['MAIL_SERVER']='sandbox.smtp.mailtrap.io'
-app.config['MAIL_PORT'] = 2525
-app.config['MAIL_USERNAME'] = '9308d9fabc9dd9'
-app.config['MAIL_PASSWORD'] = '449db778deda39'
-app.config['MAIL_USE_TLS'] = True
-app.config['MAIL_USE_SSL'] = False
+def _bool_env(name: str, default: str = 'False') -> bool:
+    return os.getenv(name, default).lower() in {'true', '1', 't', 'yes'}
+
+
+app.config['MAIL_SERVER'] = os.getenv('MAIL_SERVER', 'sandbox.smtp.mailtrap.io')
+app.config['MAIL_PORT'] = int(os.getenv('MAIL_PORT', 2525))
+app.config['MAIL_USERNAME'] = os.getenv('MAIL_USERNAME', '9308d9fabc9dd9')
+app.config['MAIL_PASSWORD'] = os.getenv('MAIL_PASSWORD', '449db778deda39')
+app.config['MAIL_USE_TLS'] = _bool_env('MAIL_USE_TLS', 'True')
+app.config['MAIL_USE_SSL'] = _bool_env('MAIL_USE_SSL', 'False')
+app.config['MAIL_DEFAULT_SENDER'] = os.getenv('MAIL_DEFAULT_SENDER', 'Imperium <no-reply@imperium.com>')
 
 db.init_app(app)  # só inicializa, não crie outro db!
 migrate = Migrate(app, db)

--- a/forms.py
+++ b/forms.py
@@ -1,7 +1,23 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, FloatField, IntegerField, TextAreaField, SubmitField, SelectField, PasswordField, DateField
+from wtforms import (
+    StringField,
+    FloatField,
+    IntegerField,
+    TextAreaField,
+    SubmitField,
+    SelectField,
+    PasswordField,
+    DateField,
+)
 from flask_wtf.file import FileField, FileAllowed
-from wtforms.validators import DataRequired
+from wtforms.validators import DataRequired, Email, EqualTo, Length, Regexp
+
+
+senha_policy = [
+    Length(min=6, message="Mínimo de 6 caracteres."),
+    Regexp(r".*[A-Z].*", message="Inclua pelo menos 1 letra maiúscula."),
+    Regexp(r".*\d.*", message="Inclua pelo menos 1 número."),
+]
 
 class ProductForm(FlaskForm):
     nome = StringField('Nome', validators=[DataRequired()])
@@ -24,3 +40,41 @@ class AdminLoginForm(FlaskForm):
     email = StringField('E-mail', validators=[DataRequired()])
     senha = PasswordField('Senha', validators=[DataRequired()])
     submit = SubmitField('Entrar')
+
+
+class RegisterForm(FlaskForm):
+    nome = StringField("Nome", validators=[DataRequired(), Length(min=2, max=100)])
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    senha = PasswordField("Senha", validators=[DataRequired(), *senha_policy])
+    confirmar = PasswordField(
+        "Confirmar senha", validators=[DataRequired(), EqualTo('senha')]
+    )
+    submit = SubmitField("Cadastrar")
+
+
+class LoginForm(FlaskForm):
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    senha = PasswordField("Senha", validators=[DataRequired()])
+    submit = SubmitField("Entrar")
+
+
+class RequestResetForm(FlaskForm):
+    email = StringField("Email", validators=[DataRequired(), Email()])
+    submit = SubmitField("Enviar link de recuperação")
+
+
+class ResetPasswordForm(FlaskForm):
+    senha = PasswordField("Nova senha", validators=[DataRequired(), *senha_policy])
+    confirmar = PasswordField(
+        "Confirmar senha", validators=[DataRequired(), EqualTo('senha')]
+    )
+    submit = SubmitField("Alterar senha")
+
+
+class ChangePasswordForm(FlaskForm):
+    atual = PasswordField("Senha atual", validators=[DataRequired()])
+    nova = PasswordField("Nova senha", validators=[DataRequired(), *senha_policy])
+    confirmar = PasswordField(
+        "Confirmar nova senha", validators=[DataRequired(), EqualTo('nova')]
+    )
+    submit = SubmitField("Atualizar senha")

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ MarkupSafe==3.0.2
 mysql-connector-python==9.2.0
 psycopg2-binary==2.9.6
 PyJWT==2.9.0
+python-dotenv==1.0.1
 python-dateutil==2.9.0.post0
 pytz==2025.2
 requests==2.32.4

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,21 +1,32 @@
 from flask import Blueprint, render_template, redirect, url_for, flash, request
-from models.usuario import Usuario
-from models import db
 from flask_login import login_user, logout_user, login_required, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
-from utils.email_utils import enviar_email
-from flask import request
-from utils.ipapi_utils import obter_localizacao_por_ip
+
+from forms import (
+    RegisterForm,
+    LoginForm,
+    RequestResetForm,
+    ResetPasswordForm,
+    ChangePasswordForm,
+)
+from models import db
 from models.admin_log import AdminLog
+from models.usuario import Usuario
+from utils.email_utils import enviar_email
+from utils.ipapi_utils import obter_localizacao_por_ip
+from utils.mail_utils import send_email
+from utils.token_utils import generate_token, confirm_token
 
 
 bp = Blueprint('auth', __name__, url_prefix='/auth')
 
+
 @bp.route('/login', methods=['GET', 'POST'])
 def login():
-    if request.method == 'POST':
-        email = request.form['email']
-        senha = request.form['senha']
+    form = LoginForm()
+    if form.validate_on_submit():
+        email = form.email.data.strip().lower()
+        senha = form.senha.data
         user = Usuario.query.filter_by(email=email).first()
         if user and check_password_hash(user.senha, senha):
             if not user.verificado:
@@ -37,24 +48,27 @@ def login():
             # --- FIM DO LOG ---
             flash("Login realizado com sucesso!", "success")
             return redirect(url_for('loja.index'))
-        flash('Login inválido')
-    return render_template('login.html')
+        flash('E-mail ou senha inválidos.', 'danger')
+    return render_template('login.html', form=form)
+
 
 @bp.route('/cadastro', methods=['GET', 'POST'])
 def cadastro():
-    if request.method == 'POST':
+    form = RegisterForm()
+    if form.validate_on_submit():
         from app import serializer  # Importa dentro da função para evitar import circular
-        nome = request.form['nome']
-        email = request.form['email']
-        senha = generate_password_hash(request.form['senha'])
+
+        nome = form.nome.data.strip()
+        email = form.email.data.strip().lower()
+        senha = generate_password_hash(form.senha.data)
 
         if Usuario.query.filter_by(email=email).first():
-            flash("Este e-mail já está em uso. Tente outro.", "danger")
-            return render_template("cadastro.html")
+            form.email.errors.append("Este e-mail já está em uso. Tente outro.")
+            return render_template("cadastro.html", form=form)
 
         if Usuario.query.filter_by(nome=nome).first():
-            flash("Este nome de usuário já está em uso. Escolha outro.", "danger")
-            return render_template("cadastro.html")
+            form.nome.errors.append("Este nome de usuário já está em uso. Escolha outro.")
+            return render_template("cadastro.html", form=form)
 
         novo_usuario = Usuario(nome=nome, email=email, senha=senha)
         db.session.add(novo_usuario)
@@ -73,7 +87,7 @@ def cadastro():
         flash("Cadastro realizado com sucesso! Verifique seu e-mail.", "success")
         return redirect(url_for('auth.login'))
 
-    return render_template("cadastro.html")
+    return render_template("cadastro.html", form=form)
 
 @bp.route('/logout')
 @login_required
@@ -97,3 +111,50 @@ def confirmar_email(token):
         return 'Conta confirmada com sucesso!'
     else:
         return 'Usuário não encontrado.'
+
+
+@bp.route('/reset-password', methods=['GET', 'POST'])
+def reset_password_request():
+    form = RequestResetForm()
+    if form.validate_on_submit():
+        user = Usuario.query.filter_by(email=form.email.data.strip().lower()).first()
+        if user:
+            token = generate_token(user.email)
+            reset_link = url_for('auth.reset_password_token', token=token, _external=True)
+            html = render_template('emails/reset_password.html', user=user, reset_link=reset_link)
+            send_email(user.email, "Recuperação de senha - Imperium", html)
+        flash("Se o e-mail existir, enviaremos um link de recuperação.", "info")
+        return redirect(url_for('auth.login'))
+    return render_template('auth/reset_password_request.html', form=form)
+
+
+@bp.route('/reset-password/<token>', methods=['GET', 'POST'])
+def reset_password_token(token):
+    email = confirm_token(token)
+    if not email:
+        flash("Link inválido ou expirado.", "danger")
+        return redirect(url_for('auth.reset_password_request'))
+
+    form = ResetPasswordForm()
+    if form.validate_on_submit():
+        user = Usuario.query.filter_by(email=email.lower()).first_or_404()
+        user.senha = generate_password_hash(form.senha.data)
+        db.session.commit()
+        flash("Senha alterada com sucesso. Faça login.", "success")
+        return redirect(url_for('auth.login'))
+    return render_template('auth/reset_password_form.html', form=form)
+
+
+@bp.route('/change-password', methods=['GET', 'POST'])
+@login_required
+def change_password():
+    form = ChangePasswordForm()
+    if form.validate_on_submit():
+        if not check_password_hash(current_user.senha, form.atual.data):
+            flash("Senha atual incorreta.", "danger")
+        else:
+            current_user.senha = generate_password_hash(form.nova.data)
+            db.session.commit()
+            flash("Senha atualizada.", "success")
+            return redirect(url_for('loja.meus_pedidos'))
+    return render_template('auth/change_password.html', form=form)

--- a/templates/auth/change_password.html
+++ b/templates/auth/change_password.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block title %}Alterar senha - Imperium{% endblock %}
+{% block content %}
+<section class="auth-section">
+  <div class="auth-card">
+    <h2>Alterar senha</h2>
+    <p class="auth-subtitle">Atualize sua senha para manter sua conta segura.</p>
+    <form method="POST" class="auth-form">
+      {{ form.hidden_tag() }}
+      <div class="input-group">
+        <label for="atual">Senha atual</label>
+        <input type="password" id="atual" name="atual" placeholder="Senha atual" required>
+        {% if form.atual.errors %}
+          <small class="text-danger">{{ form.atual.errors[0] }}</small>
+        {% endif %}
+      </div>
+      <div class="input-group password-group">
+        <label for="nova">Nova senha</label>
+        <input type="password" id="nova" name="nova" placeholder="Nova senha" required>
+        {% if form.nova.errors %}
+          <small class="text-danger">{{ form.nova.errors[0] }}</small>
+        {% endif %}
+        <small class="text-muted">
+          A senha deve ter <strong>6+ caracteres</strong>, pelo menos <strong>1 letra maiúscula</strong> e <strong>1 número</strong>.
+        </small>
+      </div>
+      <div class="input-group">
+        <label for="confirmar">Confirmar nova senha</label>
+        <input type="password" id="confirmar" name="confirmar" placeholder="Repita a nova senha" required>
+        {% if form.confirmar.errors %}
+          <small class="text-danger">{{ form.confirmar.errors[0] }}</small>
+        {% endif %}
+      </div>
+      <button type="submit" class="auth-submit">Atualizar senha</button>
+    </form>
+    <div class="auth-links">
+      <a class="auth-link" href="{{ url_for('loja.meus_pedidos') }}">Voltar à conta</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/auth/reset_password_form.html
+++ b/templates/auth/reset_password_form.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block title %}Definir nova senha - Imperium{% endblock %}
+{% block content %}
+<section class="auth-section">
+  <div class="auth-card">
+    <h2>Nova senha</h2>
+    <p class="auth-subtitle">Crie uma nova senha para sua conta.</p>
+    <form method="POST" class="auth-form">
+      {{ form.hidden_tag() }}
+      <div class="input-group password-group">
+        <label for="senha">Nova senha</label>
+        <input type="password" id="senha" name="senha" placeholder="Crie uma senha" required>
+        {% if form.senha.errors %}
+          <small class="text-danger">{{ form.senha.errors[0] }}</small>
+        {% endif %}
+        <small class="text-muted">
+          A senha deve ter <strong>6+ caracteres</strong>, pelo menos <strong>1 letra maiúscula</strong> e <strong>1 número</strong>.
+        </small>
+      </div>
+      <div class="input-group">
+        <label for="confirmar">Confirmar senha</label>
+        <input type="password" id="confirmar" name="confirmar" placeholder="Repita a senha" required>
+        {% if form.confirmar.errors %}
+          <small class="text-danger">{{ form.confirmar.errors[0] }}</small>
+        {% endif %}
+      </div>
+      <button type="submit" class="auth-submit">Alterar senha</button>
+    </form>
+    <div class="auth-links">
+      <a class="auth-link" href="{{ url_for('auth.login') }}">Voltar ao login</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/auth/reset_password_request.html
+++ b/templates/auth/reset_password_request.html
@@ -1,0 +1,31 @@
+{% extends 'base.html' %}
+{% block title %}Recuperar senha - Imperium{% endblock %}
+{% block content %}
+<section class="auth-section">
+  <div class="auth-card">
+    <h2>Recuperar senha</h2>
+    <p class="auth-subtitle">Informe o e-mail cadastrado para receber o link de recuperação.</p>
+    <form method="POST" class="auth-form">
+      {{ form.hidden_tag() }}
+      <div class="input-group">
+        <label for="email">E-mail</label>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          placeholder="nome@imperium.com"
+          value="{{ form.email.data or '' }}"
+          required
+        >
+        {% if form.email.errors %}
+          <small class="text-danger">{{ form.email.errors[0] }}</small>
+        {% endif %}
+      </div>
+      <button type="submit" class="auth-submit">Enviar link</button>
+    </form>
+    <div class="auth-links">
+      <a class="auth-link" href="{{ url_for('auth.login') }}">Voltar ao login</a>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/templates/cadastro.html
+++ b/templates/cadastro.html
@@ -6,15 +6,34 @@
     <h2>Criar conta</h2>
     <p class="auth-subtitle">Cadastre-se para acessar ofertas exclusivas.</p>
     <form method="POST" class="auth-form">
-      {# Mantemos compatibilidade com WTForms caso o backend injete um form #}
       {{ form.hidden_tag() if form is defined }}
       <div class="input-group">
         <label for="nome">Nome completo</label>
-        <input type="text" id="nome" name="nome" placeholder="Seu nome" required>
+        <input
+          type="text"
+          id="nome"
+          name="nome"
+          placeholder="Seu nome"
+          value="{{ form.nome.data if form is defined else '' }}"
+          required
+        >
+        {% if form is defined and form.nome.errors %}
+          <small class="text-danger">{{ form.nome.errors[0] }}</small>
+        {% endif %}
       </div>
       <div class="input-group">
         <label for="email">E-mail</label>
-        <input type="email" id="email" name="email" placeholder="nome@imperium.com" required>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          placeholder="nome@imperium.com"
+          value="{{ form.email.data if form is defined else '' }}"
+          required
+        >
+        {% if form is defined and form.email.errors %}
+          <small class="text-danger">{{ form.email.errors[0] }}</small>
+        {% endif %}
       </div>
       <div class="input-group password-group">
         <label for="senha">Senha</label>
@@ -24,6 +43,19 @@
             <img id="olho" src="{{ url_for('static', filename='img/view.png') }}" alt="Mostrar senha">
           </button>
         </div>
+        {% if form is defined and form.senha.errors %}
+          <small class="text-danger">{{ form.senha.errors[0] }}</small>
+        {% endif %}
+        <small class="text-muted">
+          A senha deve ter <strong>6+ caracteres</strong>, pelo menos <strong>1 letra maiúscula</strong> e <strong>1 número</strong>.
+        </small>
+      </div>
+      <div class="input-group">
+        <label for="confirmar">Confirmar senha</label>
+        <input type="password" id="confirmar" name="confirmar" placeholder="Repita a senha" required>
+        {% if form is defined and form.confirmar.errors %}
+          <small class="text-danger">{{ form.confirmar.errors[0] }}</small>
+        {% endif %}
       </div>
       <button type="submit" class="auth-submit">Cadastrar</button>
     </form>

--- a/templates/emails/reset_password.html
+++ b/templates/emails/reset_password.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Recuperação de senha - Imperium</title>
+</head>
+<body>
+  <h1>Olá, {{ user.nome }}!</h1>
+  <p>Recebemos uma solicitação para redefinir a senha da sua conta na Imperium.</p>
+  <p>Para criar uma nova senha, clique no botão abaixo:</p>
+  <p>
+    <a href="{{ reset_link }}" style="display:inline-block;padding:12px 20px;background-color:#4f46e5;color:#ffffff;text-decoration:none;border-radius:6px;">Redefinir senha</a>
+  </p>
+  <p>Se você não solicitou esta alteração, ignore este e-mail. O link expira em 1 hora.</p>
+  <p>Equipe Imperium</p>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,11 +6,20 @@
     <h2>Entrar</h2>
     <p class="auth-subtitle">Use suas credenciais para continuar comprando.</p>
     <form method="POST" class="auth-form">
-      {# Mantemos compatibilidade com WTForms caso o backend injete um form #}
       {{ form.hidden_tag() if form is defined }}
       <div class="input-group">
         <label for="email">E-mail</label>
-        <input type="email" id="email" name="email" placeholder="nome@imperium.com" required>
+        <input
+          type="email"
+          id="email"
+          name="email"
+          placeholder="nome@imperium.com"
+          value="{{ form.email.data if form is defined else '' }}"
+          required
+        >
+        {% if form is defined and form.email.errors %}
+          <small class="text-danger">{{ form.email.errors[0] }}</small>
+        {% endif %}
       </div>
       <div class="input-group password-group">
         <label for="senha">Senha</label>
@@ -20,9 +29,15 @@
             <img id="olho" src="{{ url_for('static', filename='img/view.png') }}" alt="Mostrar senha">
           </button>
         </div>
+        {% if form is defined and form.senha.errors %}
+          <small class="text-danger">{{ form.senha.errors[0] }}</small>
+        {% endif %}
       </div>
       <button type="submit" class="auth-submit">Entrar</button>
     </form>
+    <div class="auth-links">
+      <a class="auth-link" href="{{ url_for('auth.reset_password_request') }}">Esqueci minha senha</a>
+    </div>
     <p class="auth-switch">Não tem conta? <a href="{{ url_for('auth.cadastro') }}">Crie agora mesmo</a>.</p>
   </div>
 </section>

--- a/templates/usuario.html
+++ b/templates/usuario.html
@@ -37,14 +37,12 @@
       </dl>
       <div class="account-security">
         <p>Segurança da conta</p>
-        <button class="account-action-btn full" type="button">
-          <!-- Placeholder de fluxo de alteração de senha -->
+        <a class="account-action-btn full" href="{{ url_for('auth.change_password') }}">
           Alterar senha
-        </button>
-        <button class="account-action-btn link" type="button">
-          <!-- Placeholder de fluxo de recuperação de acesso -->
+        </a>
+        <a class="account-action-btn link" href="{{ url_for('auth.reset_password_request') }}">
           Recuperar acesso
-        </button>
+        </a>
       </div>
     </section>
 

--- a/utils/mail_utils.py
+++ b/utils/mail_utils.py
@@ -1,0 +1,16 @@
+from flask import current_app
+from flask_mail import Message
+
+
+def send_email(to: str, subject: str, html: str) -> None:
+    mail = current_app.extensions.get('mail')
+    if mail is None:
+        raise RuntimeError('Flask-Mail não está configurado no aplicativo atual.')
+
+    msg = Message(
+        subject=subject,
+        recipients=[to],
+        html=html,
+        sender=current_app.config.get('MAIL_DEFAULT_SENDER'),
+    )
+    mail.send(msg)

--- a/utils/token_utils.py
+++ b/utils/token_utils.py
@@ -1,0 +1,15 @@
+from itsdangerous import URLSafeTimedSerializer
+from flask import current_app
+
+
+def generate_token(email: str) -> str:
+    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    return s.dumps(email, salt="password-reset")
+
+
+def confirm_token(token: str, max_age: int = 3600) -> str | None:
+    s = URLSafeTimedSerializer(current_app.config['SECRET_KEY'])
+    try:
+        return s.loads(token, salt="password-reset", max_age=max_age)
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- enforce the new password policy across the registration, login, and password management forms
- add token and email utilities plus templates to deliver reset links and support the change/reset flows
- wire the auth routes and templates to use WTForms, expose change/reset pages, and load mail settings from the environment

## Testing
- python -m compileall forms.py routes/auth_routes.py utils templates/auth

------
https://chatgpt.com/codex/tasks/task_e_68def72336d08328bbfdae3a2430c8f9