### PR TITLE
Handle product deactivation when referenced

### DIFF
--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -11,6 +11,7 @@ from models.admin_log import AdminLog
 from forms import ProductForm, OrderFilterForm, AdminLoginForm, IMAGE_EXTENSIONS
 from werkzeug.utils import secure_filename
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 import os, io, csv
 from datetime import datetime, time
 from utils.ipapi_utils import obter_localizacao_por_ip
@@ -287,10 +288,32 @@ def produto_excluir(produto_id):
     if not current_user.admin:
         return redirect(url_for('loja.index'))
     produto = Produto.query.get_or_404(produto_id)
-    db.session.delete(produto)
+    try:
+        db.session.delete(produto)
+        db.session.commit()
+        log_action(f'Excluiu produto {produto.nome}')
+        flash('Produto excluído.', 'success')
+    except IntegrityError:
+        db.session.rollback()
+        produto.ativo = False
+        db.session.commit()
+        log_action(f'Desativou produto {produto.nome} (referências em pedidos)')
+        flash('Produto possui pedidos vinculados. Foi DESATIVADO em vez de excluído.', 'warning')
+
+    return redirect(url_for('admin.produtos'))
+
+
+@admin_bp.route('/produtos/<int:produto_id>/reativar', methods=['POST'])
+@login_required
+def produto_reativar(produto_id):
+    if not current_user.admin:
+        return redirect(url_for('loja.index'))
+
+    produto = Produto.query.get_or_404(produto_id)
+    produto.ativo = True
     db.session.commit()
-    log_action(f'Excluiu produto {produto.nome}')
-    flash('Produto excluído.', 'info')
+    log_action(f'Reativou produto {produto.nome}')
+    flash('Produto reativado.', 'success')
     return redirect(url_for('admin.produtos'))
 
 

--- a/routes/loja_routes.py
+++ b/routes/loja_routes.py
@@ -10,21 +10,26 @@ loja = Blueprint('loja', __name__)
 
 @loja.route('/')
 def index():
-    produtos = Produto.query.all()
+    produtos = Produto.query.filter_by(ativo=True).all()
     return render_template('index.html', produtos=produtos)
 
 @loja.route('/produto/<int:id>')
 def produto_detalhe(id):
     produto = Produto.query.get_or_404(id)
+    if not produto.ativo and (not current_user.is_authenticated or not current_user.admin):
+        abort(404)
     return render_template('produto_detalhe.html', produto=produto)
 
 @loja.route('/search')
 def search():
     query = request.args.get('q', '').strip()
     if query:
-        produtos = Produto.query.filter(Produto.nome.ilike(f'%{query}%')).all()
+        produtos = Produto.query.filter(
+            Produto.nome.ilike(f'%{query}%'),
+            Produto.ativo.is_(True)
+        ).all()
     else:
-        produtos = Produto.query.all()
+        produtos = Produto.query.filter_by(ativo=True).all()
     return render_template('index.html', produtos=produtos, search_query=query)
 
 @loja.route('/finalizar-compra')

--- a/templates/admin/produtos/lista.html
+++ b/templates/admin/produtos/lista.html
@@ -9,21 +9,37 @@
             <th>Nome</th>
             <th>Preço</th>
             <th>Estoque</th>
-            <th>Ações</th>
+            <th>Status</th>
+            <th class="text-end">Ações</th>
         </tr>
     </thead>
     <tbody>
-        {% for p in produtos %}
+        {% for produto in produtos %}
         <tr>
-            <td>{{ p.id }}</td>
-            <td>{{ p.nome }}</td>
-            <td>R$ {{ '%.2f'|format(p.preco) }}</td>
-            <td>{{ p.estoque }}</td>
+            <td>{{ produto.id }}</td>
+            <td>{{ produto.nome }}</td>
+            <td>R$ {{ '%.2f'|format(produto.preco) }}</td>
+            <td>{{ produto.estoque }}</td>
             <td>
-                <a href="{{ url_for('admin.produto_editar', produto_id=p.id) }}" class="btn btn-sm btn-primary">Editar</a>
-                <form method="POST" action="{{ url_for('admin.produto_excluir', produto_id=p.id) }}" style="display:inline-block;">
-                    <button class="btn btn-sm btn-danger" onclick="return confirm('Excluir produto?')">Excluir</button>
-                </form>
+                {% if produto.ativo %}
+                    <span class="badge bg-success">Ativo</span>
+                {% else %}
+                    <span class="badge bg-secondary">Desativado</span>
+                {% endif %}
+            </td>
+            <td class="text-end">
+                <a class="btn btn-sm btn-outline-primary"
+                   href="{{ url_for('admin.produto_editar', produto_id=produto.id) }}">Editar</a>
+
+                {% if produto.ativo %}
+                    <form method="post" action="{{ url_for('admin.produto_excluir', produto_id=produto.id) }}" style="display:inline">
+                        <button class="btn btn-sm btn-danger">Excluir</button>
+                    </form>
+                {% else %}
+                    <form method="post" action="{{ url_for('admin.produto_reativar', produto_id=produto.id) }}" style="display:inline">
+                        <button class="btn btn-sm btn-primary">Reativar</button>
+                    </form>
+                {% endif %}
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- switch admin product deletion to deactivate when foreign keys prevent removal and add reactivation support
- show product status and appropriate actions in the admin product list
- hide deactivated products from the storefront and guard detail pages from public access

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e449561c348328899d36a158b3b94c