### PR TITLE
Fix admin product management regressions

### DIFF
--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -11,6 +11,7 @@ from models.admin_log import AdminLog
 from forms import ProductForm, OrderFilterForm, AdminLoginForm, IMAGE_EXTENSIONS
 from werkzeug.utils import secure_filename
 from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
 import os, io, csv
 from datetime import datetime, time
 from utils.ipapi_utils import obter_localizacao_por_ip
@@ -288,8 +289,14 @@ def produto_excluir(produto_id):
         return redirect(url_for('loja.index'))
 
     produto = Produto.query.get_or_404(produto_id)
-    db.session.delete(produto)
-    db.session.commit()
+    try:
+        db.session.delete(produto)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        flash('Não é possível excluir este produto pois existem pedidos associados a ele.', 'danger')
+        return redirect(url_for('admin.produtos'))
+
     log_action(f'Excluiu produto {produto.nome}')
     flash('Produto excluído.', 'info')
     return redirect(url_for('admin.produtos'))

--- a/templates/admin/produtos/form.html
+++ b/templates/admin/produtos/form.html
@@ -52,13 +52,15 @@
     <p class="text-muted">Você pode cadastrar até 4 imagens extras combinando uploads e URLs.</p>
     <div class="row g-3">
         {% for i in range(1, 5) %}
+            {% set upload_field = form['extra_' ~ i] %}
+            {% set url_field = form['extra_url_' ~ i] %}
             <div class="col-md-6">
-                <label class="form-label" for="extra_{{ i }}">Upload {{ i }}</label>
-                {{ attribute(form, 'extra_' ~ i)(class_='form-control', accept='image/*') }}
+                {{ upload_field.label(class="form-label") }}
+                {{ upload_field(class="form-control", accept='image/*') }}
             </div>
             <div class="col-md-6">
-                <label class="form-label" for="extra_url_{{ i }}">URL {{ i }}</label>
-                {{ attribute(form, 'extra_url_' ~ i)(class_='form-control', placeholder='https://exemplo.com/imagem.jpg') }}
+                {{ url_field.label(class="form-label") }}
+                {{ url_field(class="form-control", placeholder='https://exemplo.com/imagem.jpg') }}
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- render dynamic extra image fields in the admin product form without relying on the removed Jinja `attribute` helper
- prevent deleting products that are referenced by existing orders by catching integrity violations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e45467fc9c8328a03d1b859581ac4a