### PR TITLE
Simplify product detail layout

### DIFF
--- a/templates/produto.html
+++ b/templates/produto.html
@@ -3,119 +3,421 @@
 {% block title %}{{ produto.nome }} - Imperium{% endblock %}
 {% block extra_styles %}
 <style>
-  .product-detail {
-    display: grid;
-    gap: 2rem;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    align-items: start;
+  .page-product {
+    background: #f8f7f4;
+    padding: 2.5rem 0 4rem;
   }
-  .produto-visual {
+
+  .product-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 2rem;
   }
-  .produto-imagem-principal {
-    border: 1px solid #ececec;
-    border-radius: 12px;
-    padding: 1rem;
+
+  .breadcrumb {
+    font-size: 0.85rem;
+    color: #6b7280;
     display: flex;
-    justify-content: center;
+    gap: 0.5rem;
     align-items: center;
-    background: #fff;
   }
-  .produto-imagem-principal img {
-    width: 100%;
-    max-height: 420px;
+
+  .breadcrumb a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .breadcrumb span {
+    color: #9ca3af;
+  }
+
+  .product-content {
+    background: #ffffff;
+    border-radius: 18px;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+    display: grid;
+    grid-template-columns: 1.05fr 0.95fr;
+    gap: 2.5rem;
+    padding: 2.5rem;
+  }
+
+  .product-gallery {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .product-main-image {
+    border: 1px solid #d1d5db;
+    border-radius: 14px;
+    padding: 1.5rem;
+    background: #f9fafb;
+    min-height: 340px;
+    display: grid;
+    place-items: center;
+  }
+
+  .product-main-image img {
+    max-width: 100%;
+    max-height: 320px;
     object-fit: contain;
   }
-  .produto-thumbs {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+
+  .product-thumbs {
+    display: flex;
     gap: 0.75rem;
+    flex-wrap: wrap;
   }
-  .produto-thumbs .thumb {
-    border: 1px solid #d8d8d8;
+
+  .product-thumbs button {
+    border: 1px solid #d1d5db;
+    background: #ffffff;
     border-radius: 10px;
-    padding: 0.5rem;
-    background: #fff;
+    padding: 0.35rem;
     cursor: pointer;
+    width: 62px;
+    height: 62px;
+    display: grid;
+    place-items: center;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
-  .produto-thumbs .thumb.is-active {
-    border-color: #0d6efd;
-    box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.15);
+
+  .product-thumbs button.is-active {
+    border-color: #111827;
+    box-shadow: 0 0 0 2px #111827;
   }
-  .produto-thumbs .thumb img {
-    width: 100%;
-    height: 64px;
+
+  .product-thumbs img {
+    max-width: 100%;
+    max-height: 52px;
     object-fit: contain;
   }
-  @media (max-width: 576px) {
-    .produto-imagem-principal img {
-      max-height: 320px;
+
+  .product-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  .product-summary h1 {
+    font-size: 2rem;
+    margin: 0;
+    color: #111827;
+  }
+
+  .product-summary .brand {
+    font-size: 0.95rem;
+    color: #6b7280;
+  }
+
+  .price-line {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .price-line .price {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #111827;
+  }
+
+  .stock {
+    font-size: 0.95rem;
+    color: #2563eb;
+  }
+
+  .stock.is-out {
+    color: #dc2626;
+  }
+
+  .purchase-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .purchase-actions a,
+  .purchase-actions button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.85rem 1.75rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    border: none;
+    cursor: pointer;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .purchase-actions .buy-button {
+    background: #111827;
+    color: #ffffff;
+  }
+
+  .purchase-actions .buy-button:hover {
+    background: #1f2937;
+  }
+
+  .purchase-actions .buy-button[disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .purchase-actions .help-link {
+    background: transparent;
+    color: #111827;
+    border: 1px solid #d1d5db;
+  }
+
+  .purchase-actions .help-link:hover {
+    border-color: #9ca3af;
+  }
+
+  .summary-description {
+    color: #4b5563;
+    font-size: 1rem;
+    line-height: 1.6;
+  }
+
+  .info-blocks {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  }
+
+  .info-block {
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    padding: 1rem;
+    background: #f9fafb;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .info-block span {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #6b7280;
+  }
+
+  .info-block strong {
+    font-size: 0.95rem;
+    color: #111827;
+  }
+
+  .product-accordion {
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 1.5rem;
+  }
+
+  .product-accordion details {
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    background: #ffffff;
+    padding: 1rem 1.25rem;
+  }
+
+  .product-accordion summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #111827;
+    list-style: none;
+  }
+
+  .product-accordion summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .product-accordion p,
+  .product-accordion ul {
+    margin-top: 0.75rem;
+    color: #4b5563;
+    line-height: 1.6;
+    font-size: 0.95rem;
+  }
+
+  .product-accordion ul {
+    padding-left: 1.1rem;
+  }
+
+  @media (max-width: 1024px) {
+    .product-content {
+      grid-template-columns: 1fr;
+      padding: 2rem;
+    }
+
+    .purchase-actions {
+      flex-wrap: wrap;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .product-container {
+      padding: 0 1rem;
+    }
+
+    .product-content {
+      padding: 1.5rem;
+    }
+
+    .product-main-image {
+      min-height: 260px;
+    }
+
+    .purchase-actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .purchase-actions a,
+    .purchase-actions button {
+      width: 100%;
     }
   }
 </style>
 {% endblock %}
 {% block content %}
-<section class="product-detail">
-  <div class="produto-visual">
-    <div class="produto-imagem-principal">
-      <img id="img-principal" src="{{ img_src(produto.imagem) }}" alt="{{ produto.nome }}">
-    </div>
-    <div class="produto-thumbs">
-      <img class="thumb is-active" src="{{ img_src(produto.imagem) }}" data-full="{{ img_src(produto.imagem) }}" alt="{{ produto.nome }} - capa">
-      {% for extra in produto.imagens|sort(attribute='ordem') %}
-        <img class="thumb" src="{{ img_src(extra.filename) }}" data-full="{{ img_src(extra.filename) }}" alt="{{ produto.nome }} - imagem extra {{ loop.index }}">
-      {% endfor %}
-    </div>
-  </div>
+<section class="page-product">
+  <div class="product-container">
+    <nav class="breadcrumb" aria-label="Você está em">
+      <a href="{{ url_for('loja.index') }}">Loja</a>
+      <span>/</span>
+      <span>{{ produto.nome }}</span>
+    </nav>
 
-  <div class="detail-info">
-    <span class="detail-badge">Disponível{% if produto.estoque == 0 %} em breve{% endif %}</span>
-    <h1>{{ produto.nome }}</h1>
-    <div class="detail-meta">
-      <span class="price">R$ {{ '%.2f'|format(produto.preco) }}</span>
-      <span class="brand">Marca: {{ produto.marca or 'Imperium' }}</span>
-    </div>
-    <p class="stock">{% if produto.estoque > 0 %}{{ produto.estoque }} unidades em estoque{% else %}<span>Esgotado</span>{% endif %}</p>
-
-    <div class="detail-actions">
-      {% if produto.estoque > 0 %}
-        <a class="buy-button" href="{{ url_for('carrinho.adicionar_ao_carrinho', id=produto.id) }}">Adicionar ao carrinho</a>
-      {% else %}
-        <button class="buy-button" disabled>Indisponível</button>
-      {% endif %}
-    </div>
-
-    {% if produto.descricao %}
-      <div class="detail-description">
-        <h2>Descrição</h2>
-        <ul>
-          {% for linha in produto.descricao.split('\n') %}
-            {% if linha.strip() %}
-              <li>{{ linha }}</li>
-            {% endif %}
+    <div class="product-content">
+      <div class="product-gallery">
+        <div class="product-main-image">
+          <img id="img-principal" src="{{ img_src(produto.imagem) }}" alt="{{ produto.nome }}" loading="eager">
+        </div>
+        <div class="product-thumbs" role="list" aria-label="Imagens do produto {{ produto.nome }}">
+          <button type="button" class="is-active" data-full="{{ img_src(produto.imagem) }}" aria-label="Imagem principal" role="listitem">
+            <img src="{{ img_src(produto.imagem) }}" alt="{{ produto.nome }} - imagem principal">
+          </button>
+          {% for extra in produto.imagens|sort(attribute='ordem') %}
+            <button type="button" data-full="{{ img_src(extra.filename) }}" aria-label="Imagem complementar {{ loop.index }}" role="listitem">
+              <img src="{{ img_src(extra.filename) }}" alt="{{ produto.nome }} - imagem complementar {{ loop.index }}">
+            </button>
           {% endfor %}
-        </ul>
+        </div>
       </div>
-    {% endif %}
+
+      <aside class="product-summary">
+        <div>
+          <h1>{{ produto.nome }}</h1>
+          <p class="brand">{{ produto.marca or 'Imperium' }}</p>
+        </div>
+
+        <div class="price-line">
+          <span class="price">R$ {{ '%.2f'|format(produto.preco) }}</span>
+          <span class="brand">Parcelamento em até 10x sem juros</span>
+        </div>
+
+        <p class="stock {% if produto.estoque <= 0 %}is-out{% endif %}">
+          {% if produto.estoque > 0 %}
+            {{ produto.estoque }} unidades disponíveis para envio imediato
+          {% else %}
+            Produto indisponível no momento
+          {% endif %}
+        </p>
+
+        <div class="purchase-actions">
+          {% if produto.estoque > 0 %}
+            <a class="buy-button" href="{{ url_for('carrinho.adicionar_ao_carrinho', id=produto.id) }}">Adicionar ao carrinho</a>
+          {% else %}
+            <button class="buy-button" disabled>Indisponível</button>
+          {% endif %}
+          <a class="help-link" href="{{ url_for('loja.index') }}#contato">Falar com um especialista</a>
+        </div>
+
+        <p class="summary-description">
+          Tecnologia selecionada pela Imperium com foco em desempenho consistente e construção confiável para o seu setup.
+        </p>
+
+        <div class="info-blocks" aria-label="Informações rápidas">
+          <div class="info-block">
+            <span>Frete</span>
+            <strong>Envio para todo o Brasil</strong>
+          </div>
+          <div class="info-block">
+            <span>Garantia</span>
+            <strong>12 meses oficial</strong>
+          </div>
+          <div class="info-block">
+            <span>Pagamento</span>
+            <strong>Até 10x sem juros</strong>
+          </div>
+        </div>
+
+        <div class="product-accordion">
+          {% if produto.descricao %}
+            <details open>
+              <summary>Descrição</summary>
+              <ul>
+                {% for linha in produto.descricao.split('\n') %}
+                  {% if linha.strip() %}
+                    <li>{{ linha }}</li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
+            </details>
+          {% endif %}
+          <details>
+            <summary>Na caixa</summary>
+            <ul>
+              <li>{{ produto.nome }}{% if produto.marca %} da {{ produto.marca }}{% endif %}</li>
+              <li>Documentação e guia rápido</li>
+              <li>Cabo(s) e acessórios originais</li>
+            </ul>
+          </details>
+          <details>
+            <summary>Envio e suporte</summary>
+            <p>Oferecemos rastreamento em tempo real, embalagem reforçada e atendimento dedicado caso precise de ajuda com instalação ou dúvidas sobre o produto.</p>
+          </details>
+        </div>
+      </aside>
+    </div>
   </div>
 </section>
 {% endblock %}
 {% block extra_scripts %}
 <script>
-  document.addEventListener('DOMContentLoaded', function () {
+  document.addEventListener('DOMContentLoaded', () => {
     const mainImage = document.getElementById('img-principal');
-    document.querySelectorAll('.produto-thumbs .thumb').forEach(function (thumb) {
-      thumb.addEventListener('click', function () {
-        const full = thumb.getAttribute('data-full');
-        if (full && mainImage) {
-          mainImage.src = full;
-          document.querySelectorAll('.produto-thumbs .thumb').forEach(function (img) {
-            img.classList.remove('is-active');
-          });
-          thumb.classList.add('is-active');
+    const thumbs = Array.from(document.querySelectorAll('.product-thumbs button'));
+
+    if (!mainImage || thumbs.length === 0) return;
+
+    const setActive = (button) => {
+      thumbs.forEach((thumb) => thumb.classList.remove('is-active'));
+      button.classList.add('is-active');
+      const full = button.getAttribute('data-full');
+      if (full) {
+        mainImage.src = full;
+      }
+      const alt = button.querySelector('img')?.getAttribute('alt');
+      if (alt) {
+        mainImage.alt = alt;
+      }
+    };
+
+    thumbs.forEach((button) => {
+      button.addEventListener('click', () => setActive(button));
+      button.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          setActive(button);
         }
       });
     });


### PR DESCRIPTION
## Summary
- redesign the product detail template with a clean two-column layout similar to the provided reference
- streamline styling for gallery, pricing, and info blocks to focus on a neutral palette and simple structure
- replace complex interactions with a minimal thumbnail switcher script for complementary images

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6a6dfbcb88328854478f911501664